### PR TITLE
Add support for except: :destroy option in jsonapi_resources method

### DIFF
--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -81,6 +81,8 @@ module ActionDispatch
           res = JSONAPI::Resource.resource_for(resource_type_with_module_prefix(@resource_type))
 
           options = resources.extract_options!.dup
+
+
           options[:controller] ||= @resource_type
           options.merge!(res.routing_resource_options)
 
@@ -97,8 +99,9 @@ module ActionDispatch
             options[:except] = Array(options[:except])
             options[:except] << :new unless options[:except].include?(:new) || options[:except].include?('new')
             options[:except] << :edit unless options[:except].include?(:edit) || options[:except].include?('edit')
+            options[:except] << :destroy unless options[:except].include?(:destroy) || options[:except].include?('destroy')
           else
-            options[:except] = [:new, :edit]
+            options[:except] = [:new, :edit, :destroy]
           end
 
           if res._immutable

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -81,8 +81,6 @@ module ActionDispatch
           res = JSONAPI::Resource.resource_for(resource_type_with_module_prefix(@resource_type))
 
           options = resources.extract_options!.dup
-
-
           options[:controller] ||= @resource_type
           options.merge!(res.routing_resource_options)
 


### PR DESCRIPTION

### All Submissions:

- [ ] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [ ] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [ ] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions