### PR TITLE
Y25-318 Publish gem as sanger-jsonapi-resources

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ 'develop' ]
+  pull_request:
+    branches: ['**']
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.3'
+          - '3.2'
+        rails:
+          - '7.1'
+          - '7.2'
+        database_url:
+          - sqlite3:test_db
+    env:
+      RAILS_VERSION: ${{ matrix.rails }}
+      DATABASE_URL: ${{ matrix.database_url }}
+    name: Ruby ${{ matrix.ruby }} Rails ${{ matrix.rails }} DB ${{ matrix.database_url }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 platforms :ruby do
-  gem 'sqlite3', '1.3.10'
+  gem 'sqlite3', '>= 1.4'
 end
 
 platforms :jruby do
@@ -17,7 +17,7 @@ when 'master'
   gem 'railties', { git: 'https://github.com/rails/rails.git' }
   gem 'arel', { git: 'https://github.com/rails/arel.git' }
 when 'default'
-  gem 'railties', '>= 5.0'
+  gem 'railties', '~> 7.1.0'
 else
   gem 'railties', "~> #{version}"
 end

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ which *should* be compatible with JSON:API compliant server implementations such
 
 Add JR to your application's `Gemfile`:
 
-    gem 'jsonapi-resources'
+    gem 'sanger-jsonapi-resources'
 
 And then execute:
 
@@ -36,7 +36,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install jsonapi-resources
+    $ gem install sanger-jsonapi-resources
 
 **For further usage see the [v0.9 beta Guide](http://jsonapi-resources.com/v0.9/guide/)**
 

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -6,11 +6,11 @@ require 'jsonapi/resources/version'
 Gem::Specification.new do |spec|
   spec.name          = 'sanger-jsonapi-resources'
   spec.version       = JSONAPI::Resources::VERSION
-  spec.authors       = ['Dan Gebhardt', 'Larry Gebhardt']
-  spec.email         = ['dan@cerebris.com', 'larry@cerebris.com']
+  spec.authors       = ['PSD Team - Wellcome Trust Sanger Institute']
+  spec.email         = ['psd@sanger.ac.uk']
   spec.summary       = 'Easily support JSON API in Rails.'
   spec.description   = 'Forked from jsonapi-resources. A resource-centric approach to implementing the controllers, routes, and serializers needed to support the JSON API spec.'
-  spec.homepage      = 'https://github.com/cerebris/jsonapi-resources'
+  spec.homepage      = 'https://github.com/sanger/jsonapi-resources'
   spec.license       = 'MIT'
 
   spec.files         = Dir.glob("{bin,lib}/**/*") + %w(LICENSE.txt README.md)

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -4,12 +4,12 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'jsonapi/resources/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'jsonapi-resources'
+  spec.name          = 'sanger-jsonapi-resources'
   spec.version       = JSONAPI::Resources::VERSION
   spec.authors       = ['Dan Gebhardt', 'Larry Gebhardt']
   spec.email         = ['dan@cerebris.com', 'larry@cerebris.com']
   spec.summary       = 'Easily support JSON API in Rails.'
-  spec.description   = 'A resource-centric approach to implementing the controllers, routes, and serializers needed to support the JSON API spec.'
+  spec.description   = 'Forked from jsonapi-resources. A resource-centric approach to implementing the controllers, routes, and serializers needed to support the JSON API spec.'
   spec.homepage      = 'https://github.com/cerebris/jsonapi-resources'
   spec.license       = 'MIT'
 

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler', '>= 1.5', '< 3.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-spec-rails'
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord', '>= 4.1'
   spec.add_dependency 'railties', '>= 4.1'
   spec.add_dependency 'concurrent-ruby'
+  spec.add_runtime_dependency 'csv'
 end

--- a/lib/generators/jsonapi/controller_generator.rb
+++ b/lib/generators/jsonapi/controller_generator.rb
@@ -1,3 +1,4 @@
+require 'rails/generators'
 module Jsonapi
   class ControllerGenerator < Rails::Generators::NamedBase
     source_root File.expand_path('../templates', __FILE__)

--- a/lib/generators/jsonapi/resource_generator.rb
+++ b/lib/generators/jsonapi/resource_generator.rb
@@ -1,3 +1,4 @@
+require 'rails/generators'
 module Jsonapi
   class ResourceGenerator < Rails::Generators::NamedBase
     source_root File.expand_path('../templates', __FILE__)

--- a/lib/jsonapi/resources/version.rb
+++ b/lib/jsonapi/resources/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Resources
-    VERSION = '0.9.0'
+    VERSION = '0.1.1'
   end
 end

--- a/lib/sanger-jsonapi-resources.rb
+++ b/lib/sanger-jsonapi-resources.rb
@@ -1,0 +1,7 @@
+# As we are packaging 'sanger-jsonapi-resources' as a separate gem, RubyGems expects
+# the main file to be 'lib/sanger-jsonapi-resources.rb' to match the gem name.
+# Without this file, requiring the gem or Rails autoloading would fail, even if the internal code is unchanged.
+# This file exists to ensure compatibility with RubyGems and Bundler.
+# The easiest solution is to use this wrapper file, which simply requires the original 'jsonapi-resources' code,
+# so all internal references and modules remain unchanged and compatible.
+require_relative 'jsonapi-resources'

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -57,18 +57,23 @@ ActiveRecord::Schema.define do
     t.timestamps null: false
   end
 
-  create_table :posts_tags, force: true do |t|
-    t.references :post, :tag, index: true
+
+
+  create_table :posts_tags, force: true, id: false do |t|
+    t.references :post, null: false
+    t.references :tag, null: false
   end
   add_index :posts_tags, [:post_id, :tag_id], unique: true
 
   create_table :special_post_tags, force: true do |t|
-    t.references :post, :tag, index: true
+    t.references :post, null: false, foreign_key: false
+    t.references :tag, null: false, foreign_key: false
   end
   add_index :special_post_tags, [:post_id, :tag_id], unique: true
 
   create_table :comments_tags, force: true do |t|
-    t.references :comment, :tag, index: true
+    t.references :comment, null: false
+    t.references :tag, null: false
   end
 
   create_table :iso_currencies, id: false, force: true do |t|
@@ -95,7 +100,8 @@ ActiveRecord::Schema.define do
   end
 
   create_table :planets_tags, force: true do |t|
-    t.references :planet, :tag, index: true
+    t.references :planet, null: false
+    t.references :tag, null: false
   end
   add_index :planets_tags, [:planet_id, :tag_id], unique: true
 
@@ -184,7 +190,8 @@ ActiveRecord::Schema.define do
   end
 
   create_table :purchase_orders_order_flags, force: true do |t|
-    t.references :purchase_order, :order_flag, index: true
+   t.references :purchase_order, null: false
+   t.references :order_flag, null: false
   end
   add_index :purchase_orders_order_flags, [:purchase_order_id, :order_flag_id], unique: true, name: "po_flags_idx"
 
@@ -285,8 +292,8 @@ ActiveRecord::Schema.define do
 
   create_table :related_things, force: true  do |t|
     t.string :name
-    t.references :from, references: :thing
-    t.references :to, references: :thing
+    t.references :from
+    t.references :to
 
     t.timestamps null: false
   end
@@ -342,8 +349,8 @@ class Post < ActiveRecord::Base
   belongs_to :writer, class_name: 'Person', foreign_key: 'author_id'
   has_many :comments
   has_and_belongs_to_many :tags, join_table: :posts_tags
-  has_many :special_post_tags, source: :tag
-  has_many :special_tags, through: :special_post_tags, source: :tag
+  has_many :special_post_tags
+  has_many :special_tags, through: :special_post_tags
   belongs_to :section
   has_one :parent_post, class_name: 'Post', foreign_key: 'parent_post_id'
 
@@ -621,8 +628,8 @@ class Thing < ActiveRecord::Base
 end
 
 class RelatedThing < ActiveRecord::Base
-  belongs_to :from, class_name: Thing, foreign_key: :from_id
-  belongs_to :to, class_name: Thing, foreign_key: :to_id
+  belongs_to :from, class_name: 'Thing', foreign_key: :from_id
+  belongs_to :to, class_name: 'Thing', foreign_key: :to_id
 end
 
 class Question < ActiveRecord::Base


### PR DESCRIPTION
Closes https://github.com/sanger/General-Backlog-Items/issues/569

### All Submissions:
This pull request updates the gem to  `sanger-jsonapi-resources` from the [develop](https://github.com/sanger/jsonapi-resources/tree/develop) branch of  forked  [jsonapi-resources repository](https://github.com/sanger/jsonapi-resources), including adjustments to the gem name, version, and packaging to ensure compatibility with RubyGems and Bundler. The most important changes are grouped below:

### Gem Name and Metadata Updates:
* Updated the gem name from `jsonapi-resources` to `sanger-jsonapi-resources` in the `Gemfile` installation instructions within `README.md` and in the `jsonapi-resources.gemspec` file. 
* Modified the gem description in `jsonapi-resources.gemspec` to indicate that it is a fork of the original `jsonapi-resources` gem.

### ActiveRecord Fixture Updates:
 Updated table definitions to support Rails version >7.0 

### Test Suite Adjustments:
 Established the database connection before loading schemas, updated fixture paths, and removed unused Rails test helpers for streamlined testing.
 
### All Submissions:
This pull request updates the gem to  `sanger-jsonapi-resources` from the [develop](https://github.com/sanger/jsonapi-resources/tree/develop) branch of  forked  [jsonapi-resources repository](https://github.com/sanger/jsonapi-resources), including adjustments to the gem name, version, and packaging to ensure compatibility with RubyGems and Bundler. The most important changes are grouped below:

### Version Update:
* Changed the gem version from `0.9.0` to `0.1.1` in `lib/jsonapi/resources/version.rb` to reflect the fork's new versioning.
 _Version 0.1.1, as 0.1.0 has already been published with some issues. Those issues have been fixed in this version, and the version number has been bumped accordingly._
