### PR TITLE
Y25-319 - [PR] [Master] Add compatibility for obsolete Rack status symbols

### DIFF
--- a/lib/jsonapi/error.rb
+++ b/lib/jsonapi/error.rb
@@ -17,7 +17,7 @@ module JSONAPI
       @source         = options[:source]
       @links          = options[:links]
 
-      @status         = Rack::Utils::SYMBOL_TO_STATUS_CODE[options[:status]].to_s
+      @status         = Rack::Utils.status_code(options[:status]).to_s
       @meta           = options[:meta]
     end
 


### PR DESCRIPTION
Using the `Rack::Utils.status_code` method, the following status symbols can be supported for the status code 422.

Rack 2.2 `:unprocessible_entity`
Rack 3.1 `:unprocessible_content` and `:unprocessible_entity`

This PR is for releasing a new sanger-jsonapi-resources 0.2 version for Traction.