### PR TITLE
Update all references of :unprocessible_entity with :unprocessible_co…

### DIFF
--- a/lib/jsonapi/acts_as_resource_controller.rb
+++ b/lib/jsonapi/acts_as_resource_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
 require_relative 'compatibility_helper'
 module JSONAPI
   module ActsAsResourceController

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -498,7 +498,7 @@ module JSONAPI
 
       def json_api_error(attr_key, message)
         create_error_object(code: JSONAPI::VALIDATION_ERROR,
-                            status: :unprocessable_entity,
+                            status: :unprocessable_content,
                             title: message,
                             detail: detail(attr_key, message),
                             source: { pointer: pointer(attr_key) },
@@ -532,7 +532,7 @@ module JSONAPI
     class SaveFailed < Error
       def errors
         [create_error_object(code: JSONAPI::SAVE_FAILED,
-                             status: :unprocessable_entity,
+                             status: :unprocessable_content,
                              title: I18n.translate('jsonapi-resources.exceptions.save_failed.title',
                                                    default: 'Save failed or was cancelled'),
                              detail: I18n.translate('jsonapi-resources.exceptions.save_failed.detail',

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -761,7 +761,7 @@ class PostsControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     # TODO: check if this validation is working
     assert_match /author - can't be blank/, response.body
     assert_nil response.location
@@ -864,7 +864,7 @@ class PostsControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
 
     assert_equal "/data/relationships/author", json_response['errors'][0]['source']['pointer']
     assert_equal "can't be blank", json_response['errors'][0]['title']
@@ -2019,7 +2019,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_equal "can't destroy me", json_response['errors'][0]['title']
     assert_equal "/data", json_response['errors'][0]['source']['pointer']
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   def test_delete_with_validation_error_attr
@@ -2028,7 +2028,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_equal "is locked", json_response['errors'][0]['title']
     assert_equal "/data/attributes/title", json_response['errors'][0]['source']['pointer']
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   def test_delete_single
@@ -2631,7 +2631,7 @@ class PeopleControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal 2, json_response['errors'].size
     assert_equal JSONAPI::VALIDATION_ERROR, json_response['errors'][0]['code']
     assert_equal JSONAPI::VALIDATION_ERROR, json_response['errors'][1]['code']
@@ -2653,7 +2653,7 @@ class PeopleControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_equal 1, json_response['errors'].size
     assert_equal JSONAPI::VALIDATION_ERROR, json_response['errors'][0]['code']
     assert_match /name - can't be blank/, response.body
@@ -3183,7 +3183,7 @@ class FactsControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
 
     assert_equal "/data/attributes/spouse-name", json_response['errors'][0]['source']['pointer']
     assert_equal "can't be blank", json_response['errors'][0]['title']
@@ -3779,7 +3779,7 @@ class Api::V1::PlanetsControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
     assert_match /Save failed or was cancelled/, json_response['errors'][0]['detail']
   end
 end
@@ -4077,7 +4077,7 @@ class Api::V6::PostsControllerTest < ActionController::TestCase
 
     assert_equal "can't destroy me", json_response['errors'][0]['title']
     assert_equal "/data/attributes/base", json_response['errors'][0]['source']['pointer']
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 end
 


### PR DESCRIPTION
…ntent



### All Submissions:

- [X] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [X] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [X] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [X] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [X] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions