### PR TITLE
introduce UNPROCESSABLE_ENTITY_STATUS for Rack compatibility and remove deprecation warnings

### DIFF
--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 module JSONAPI
+  # HTTP 422 symbol name varies across Rack versions (:unprocessable_entity on Rack 2.x, :unprocessable_content on Rack 3.1+).
+  UNPROCESSABLE_ENTITY_STATUS =
+    if Rack::Utils::SYMBOL_TO_STATUS_CODE.key?(:unprocessable_content)
+      :unprocessable_content
+    else
+      :unprocessable_entity
+    end
+
   module Exceptions
     class Error < RuntimeError
       attr_reader :error_object_overrides
@@ -498,7 +506,7 @@ module JSONAPI
 
       def json_api_error(attr_key, message)
         create_error_object(code: JSONAPI::VALIDATION_ERROR,
-                            status: :unprocessable_entity,
+                            status: JSONAPI::UNPROCESSABLE_ENTITY_STATUS,
                             title: message,
                             detail: detail(attr_key, message),
                             source: { pointer: pointer(attr_key) },
@@ -532,7 +540,7 @@ module JSONAPI
     class SaveFailed < Error
       def errors
         [create_error_object(code: JSONAPI::SAVE_FAILED,
-                             status: :unprocessable_entity,
+                             status: JSONAPI::UNPROCESSABLE_ENTITY_STATUS,
                              title: I18n.translate('jsonapi-resources.exceptions.save_failed.title',
                                                    default: 'Save failed or was cancelled'),
                              detail: I18n.translate('jsonapi-resources.exceptions.save_failed.detail',

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -761,7 +761,7 @@ class PostsControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response JSONAPI::UNPROCESSABLE_ENTITY_STATUS
     # TODO: check if this validation is working
     assert_match /author - can't be blank/, response.body
     assert_nil response.location
@@ -864,7 +864,7 @@ class PostsControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response JSONAPI::UNPROCESSABLE_ENTITY_STATUS
 
     assert_equal "/data/relationships/author", json_response['errors'][0]['source']['pointer']
     assert_equal "can't be blank", json_response['errors'][0]['title']
@@ -2019,7 +2019,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_equal "can't destroy me", json_response['errors'][0]['title']
     assert_equal "/data", json_response['errors'][0]['source']['pointer']
-    assert_response :unprocessable_entity
+    assert_response JSONAPI::UNPROCESSABLE_ENTITY_STATUS
   end
 
   def test_delete_with_validation_error_attr
@@ -2028,7 +2028,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_equal "is locked", json_response['errors'][0]['title']
     assert_equal "/data/attributes/title", json_response['errors'][0]['source']['pointer']
-    assert_response :unprocessable_entity
+    assert_response JSONAPI::UNPROCESSABLE_ENTITY_STATUS
   end
 
   def test_delete_single
@@ -2631,7 +2631,7 @@ class PeopleControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response JSONAPI::UNPROCESSABLE_ENTITY_STATUS
     assert_equal 2, json_response['errors'].size
     assert_equal JSONAPI::VALIDATION_ERROR, json_response['errors'][0]['code']
     assert_equal JSONAPI::VALIDATION_ERROR, json_response['errors'][1]['code']
@@ -2653,7 +2653,7 @@ class PeopleControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response JSONAPI::UNPROCESSABLE_ENTITY_STATUS
     assert_equal 1, json_response['errors'].size
     assert_equal JSONAPI::VALIDATION_ERROR, json_response['errors'][0]['code']
     assert_match /name - can't be blank/, response.body
@@ -3183,7 +3183,7 @@ class FactsControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response JSONAPI::UNPROCESSABLE_ENTITY_STATUS
 
     assert_equal "/data/attributes/spouse-name", json_response['errors'][0]['source']['pointer']
     assert_equal "can't be blank", json_response['errors'][0]['title']
@@ -3779,7 +3779,7 @@ class Api::V1::PlanetsControllerTest < ActionController::TestCase
         }
       }
 
-    assert_response :unprocessable_entity
+    assert_response JSONAPI::UNPROCESSABLE_ENTITY_STATUS
     assert_match /Save failed or was cancelled/, json_response['errors'][0]['detail']
   end
 end
@@ -4077,7 +4077,7 @@ class Api::V6::PostsControllerTest < ActionController::TestCase
 
     assert_equal "can't destroy me", json_response['errors'][0]['title']
     assert_equal "/data/attributes/base", json_response['errors'][0]['source']['pointer']
-    assert_response :unprocessable_entity
+    assert_response JSONAPI::UNPROCESSABLE_ENTITY_STATUS
   end
 end
 

--- a/test/unit/exceptions/status_code_test.rb
+++ b/test/unit/exceptions/status_code_test.rb
@@ -1,0 +1,22 @@
+require File.expand_path('../../../test_helper', __FILE__)
+require 'jsonapi-resources'
+
+class UnprocessableEntityStatusTest < ActiveSupport::TestCase
+  def test_resolves_to_a_symbol_rack_recognizes
+    assert Rack::Utils::SYMBOL_TO_STATUS_CODE.key?(JSONAPI::UNPROCESSABLE_ENTITY_STATUS),
+           "JSONAPI::UNPROCESSABLE_ENTITY_STATUS (#{JSONAPI::UNPROCESSABLE_ENTITY_STATUS.inspect}) " \
+           "should be a key in Rack::Utils::SYMBOL_TO_STATUS_CODE on the installed Rack (#{Rack.release})"
+  end
+
+  def test_resolves_to_http_422
+    assert_equal 422, Rack::Utils::SYMBOL_TO_STATUS_CODE[JSONAPI::UNPROCESSABLE_ENTITY_STATUS]
+  end
+
+  def test_prefers_unprocessable_content_when_rack_supports_it
+    if Rack::Utils::SYMBOL_TO_STATUS_CODE.key?(:unprocessable_content)
+      assert_equal :unprocessable_content, JSONAPI::UNPROCESSABLE_ENTITY_STATUS
+    else
+      assert_equal :unprocessable_entity, JSONAPI::UNPROCESSABLE_ENTITY_STATUS
+    end
+  end
+end


### PR DESCRIPTION

## Summary

Fixes [sanger/jsonapi-resources#7](https://github.com/sanger/jsonapi-resources/issues/7) by replacing deprecated :unprocessable_entity with a Rack-compatible constant.

Introduces JSONAPI::UNPROCESSABLE_ENTITY_STATUS to support both Rack 2.x and 3.x:

-Uses :unprocessable_content on newer Rack versions
-Falls back to :unprocessable_entity for older versions

This removes deprecation warnings in validation/save-failed flows and updates tests accordingly.