### PR TITLE
Fix for Rails 8.1 [Sequencescape] 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,11 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.3'
           - '3.2'
+          - '3.3'
+          - '3.4'
         rails:
           - '7.1'
           - '7.2'
+          - '8.0'
+          - '8.1'
         database_url:
           - sqlite3:test_db
     env:
@@ -25,7 +28,7 @@ jobs:
       DATABASE_URL: ${{ matrix.database_url }}
     name: Ruby ${{ matrix.ruby }} Rails ${{ matrix.rails }} DB ${{ matrix.database_url }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 platforms :ruby do
-  gem 'sqlite3', '>= 1.4'
+  gem 'sqlite3', '>= 2.1'
 end
 
 platforms :jruby do
@@ -17,7 +17,7 @@ when 'master'
   gem 'railties', { git: 'https://github.com/rails/rails.git' }
   gem 'arel', { git: 'https://github.com/rails/arel.git' }
 when 'default'
-  gem 'railties', '~> 7.1.0'
+  gem 'railties', '~> 8.1.0'
 else
   gem 'railties', "~> #{version}"
 end

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.5', '< 3.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'minitest-mock'
   spec.add_development_dependency 'minitest-spec-rails'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'pry'

--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.add_development_dependency 'bundler', '>= 1.5', '< 3.0'
   spec.add_development_dependency 'rake'

--- a/lib/jsonapi/resources/version.rb
+++ b/lib/jsonapi/resources/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Resources
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -51,7 +51,7 @@ module ActionDispatch
               end
             else
               # Rails 5
-              jsonapi_resource_scope(SingletonResource.new(@resource_type, api_only?, @scope[:shallow], options), @resource_type) do
+              jsonapi_resource_scope(SingletonResource.new(@resource_type, api_only?, @scope[:shallow], **options), @resource_type) do
                 if block_given?
                   yield
                 else
@@ -119,7 +119,7 @@ module ActionDispatch
               end
             else
               # Rails 5
-              jsonapi_resource_scope(Resource.new(@resource_type, api_only?, @scope[:shallow], options), @resource_type) do
+              jsonapi_resource_scope(Resource.new(@resource_type, api_only?, @scope[:shallow], **options), @resource_type) do
                 if block_given?
                   yield
                 else

--- a/lib/jsonapi/routing_ext.rb
+++ b/lib/jsonapi/routing_ext.rb
@@ -38,7 +38,7 @@ module ActionDispatch
             options[:except] << :destroy unless options[:except].include?(:destroy) || options[:except].include?('destroy')
           end
 
-          resource @resource_type, options do
+          resource @resource_type, **options do
             # :nocov:
             if @scope.respond_to? :[]=
               # Rails 4
@@ -107,7 +107,7 @@ module ActionDispatch
             options[:except] << :destroy unless options[:except].include?(:destroy) || options[:except].include?('destroy')
           end
 
-          resources @resource_type, options do
+          resources @resource_type, **options do
             # :nocov:
             if @scope.respond_to? :[]=
               # Rails 4

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,6 +56,11 @@ class TestApp < Rails::Application
     config.active_record.time_zone_aware_types = [:time, :datetime]
     config.active_record.belongs_to_required_by_default = false
   end
+
+  # Use a modern cache serialization format to avoid Rails 7.2+ deprecations.
+  if Rails::VERSION::MAJOR >= 7 && config.active_support.respond_to?(:cache_format_version=)
+    config.active_support.cache_format_version = 7.1
+  end
 end
 
 module MyEngine


### PR DESCRIPTION
#### Changes

- Fix for Rails 8.1 compatibility in Sequencescape
- Add Ruby 3.4 and Rails 8.0 and 8.1 to test matrix

Based on merge pull request #10 from sanger/rails-8.1-fix

